### PR TITLE
Problem: 1/c4 and 2/coss don't have a type

### DIFF
--- a/1/README.md
+++ b/1/README.md
@@ -1,6 +1,7 @@
 ```
 shortname: 1/C4
 name: Collective Code Construction Contract
+type: Meta
 status: raw
 editor: Alberto Granzotto <alberto@bigchaindb.com>
 ```

--- a/2/README.md
+++ b/2/README.md
@@ -1,6 +1,7 @@
 ```
 shortname: 2/COSS
 name: Consensus-Oriented Specification System
+type: Meta
 status: raw
 editor: Alberto Granzotto <alberto@bigchaindb.com>
 contributors: Troy McConaghy <troy@bigchaindb.com>, Katha Griess <katha@bigchaindb.com>


### PR DESCRIPTION
Solution: add type "meta" to the specifications