### PR TITLE
Problem: BEP-3 not really all that "insecure"

### DIFF
--- a/3/README.md
+++ b/3/README.md
@@ -1,16 +1,15 @@
 ```
 shortname: 3/UPSERT-VALIDATORS
-name: Dynamically add/remove validators at runtime (Insecure version)
+name: Dynamically add/update/remove validators at runtime
 type: standard
 status: raw
 editor: Vanshdeep Singh <vanshdeep@bigchaindb.com>
 ```
 
-
 ## Problem Description
 In the current state of tendermint bdb, validator nodes are specified in the Tendermint config file before starting the node. It is necessary that the users should be able to dynamically add new validators.
 
-**NOTE**: This document presents an insecure implementation intended for bigchaindb tendermint MVP.
+**NOTE**: This document presents an implementation intended for BigchainDB 2.0.
 
 ### Technical details
 Tendermint allows the abci client application to return a list of validators during `end_block` call. If the client doesn't wish to modify the validators an empty list should be returned. The return value allows the client to dynamically add/remove validators. Note that the return value could be thought of as a (validators) diff of desired validators list and current validators list. Below is an example of validators diff,
@@ -94,16 +93,8 @@ Below is a summary of workflow sequence which should be executed in order to add
 
 
 ### Security impact
-The current implementation is insecure i.e. any user who gains access to a given node can modify its validators. This node could effectively be considered byzantine and the network can tolerate (<1/3) byzantine nodes.
+The current implementation is somewhat insecure because anyone who gains access to a node can modify its local list of validators. However, unless >2/3 of the nodes make the same change, it won't take effect.
 
-### Performance impact
-N/A
-
-### End user impact
-N/A
-
-### Deployment impact
-N/A
 
 ### Documentation impact
 The new api introduced should be documented along with its current state of security.
@@ -122,11 +113,7 @@ Following test cases should be included:
 Primary assignee(s): @kansi
 
 ### Targeted Release
-BigchainDB tendermint MVP
-
-
-## Dependencies
-N/A
+BigchainDB 2.0
 
 
 ## Reference(s)

--- a/3/README.md
+++ b/3/README.md
@@ -2,7 +2,7 @@
 shortname: 3/UPSERT-VALIDATORS
 name: Dynamically add/update/remove validators at runtime
 type: standard
-status: raw
+status: stable
 editor: Vanshdeep Singh <vanshdeep@bigchaindb.com>
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Short Name    | Title                                                        | T
 --------------|--------------------------------------------------------------|----------|------------|-------
 [1/C4](1)     | Collective Code Construction Contract                        | Meta     | Draft      | Alberto Granzotto
 [2/COSS](2)   | Consensus-Oriented Specification System                      | Meta     | Draft      | Alberto Granzotto
-[3/UPSERT-VALIDATORS](3) | Dynamically add/remove validators at runtime (Insecure version)  | Standard | Raw | Vanshdeep Singh
+[3/UPSERT-VALIDATORS](3) | Dynamically add/update/remove validators at runtime | Standard | Stable | Vanshdeep Singh
 [4/STANDARDIZE-DC](4) | Standard process to set up a local node for development & testing, using Docker Compose | Standard | Raw | Muawia Khan
 [5/IDRP](5)   | Illegal Data Response Plan                                   | Informational | Raw   | Troy McConaghy
 [6/SWP](6)    | Shared Workspace Protocol                                    | Meta     | Draft      | Alberto Granzotto


### PR DESCRIPTION
Solution: Update descriptions of BEP-3 so it's more consistent with the actual security of BEP-3.
          
- Also update the name of the target release to BigchainDB 2.0.
- Also update the status of BEP-3 from "raw" to "stable".