### PR TITLE
Problem: No page of transaction specs to link to

### DIFF
--- a/tx-specs/README.md
+++ b/tx-specs/README.md
@@ -1,0 +1,6 @@
+# BigchainDB Transactions Specs
+
+All BigchainDB Transactions Specs are also BigchainDB Enhancement Proposals (BEPs):
+
+- [BEP-12: BigchainDB Transactions Spec v1](https://github.com/bigchaindb/BEPs/tree/master/12). Such transactions work with BigchainDB Server 1.0 through 1.3.
+- [BEP-13: BigchainDB Transactions Spec v2](https://github.com/bigchaindb/BEPs/tree/master/13). Such transactions work with BigchainDB Server 2.0.


### PR DESCRIPTION
Solution: Create a page listing all transaction specs, hyperlinking each one to the spec in question.

I ran into this problem when updating the BigchainDB docs (root docs, server docs and Contributing docs). I wanted to make links to the "IPDB Transaction Spec" into links to something else, but _what_? The reader needs a list of all the transaction specs, with help to determine which one (or ones) are relevant to them.