### PR TITLE
In v2, transaction operation can't be "GENESIS"

### DIFF
--- a/12/README.md
+++ b/12/README.md
@@ -712,6 +712,11 @@ Note: The first two rules prevent double spending.
 
 Regardless of whether the transaction is a CREATE or TRANSFER transaction: For all inputs, `input.fulfillment` must be valid. See the <a href="#transaction-components-inputs"><span>section about inputs</span></a> for more details about what that means.
 
+#### More Rules
+
+Some implementations of the BigchainDB Transactions Spec impose more rules. See the section titled [Implementation-Specific Deviations](#implementation-specific-deviations).
+
+
 ## Implementation-Specific Deviations
 
 Some implementations of BigchainDB-compliant servers or drivers deviate from the BigchainDB Transaction Spec.

--- a/13/README.md
+++ b/13/README.md
@@ -461,8 +461,6 @@ To change it into a 1-of-2 condition, just change the value of `threshold` to 1 
 
 The operation indicates the type/kind of transaction, and how it should be validated. It must be a string. The allowed values are `"CREATE"` and `"TRANSFER"`.
 
-Note: Some implementations may allow other values, but maybe only internally. For example, BigchainDB Server allows the value `"GENESIS"`. See <a href="#implementation-specific-deviations"><span>the section about implementation-specific deviations</span></a>.
-
 ### Transaction Components: Asset
 
 In a CREATE transaction, an asset can be <a href="#ctnull"><span>ctnull</span></a> (e.g. `None` in Python), or an <a href="#associative-array"><span>associative array</span></a> containing exactly one key-value pair. The key must be `"data"` and the value can be any valid associative array. Here’s a JSON example:
@@ -749,6 +747,11 @@ Note: The first two rules prevent double spending.
 
 Regardless of whether the transaction is a CREATE or TRANSFER transaction: For all inputs, `input.fulfillment` must be valid. See the <a href="#transaction-components-inputs"><span>section about inputs</span></a> for more details about what that means.
 
+#### More Rules
+
+Some implementations of the BigchainDB Transactions Spec impose more rules. See the section titled [Implementation-Specific Deviations](#implementation-specific-deviations).
+
+
 ## Implementation-Specific Deviations
 
 Some implementations of BigchainDB-compliant servers or drivers deviate from the BigchainDB Transaction Spec.
@@ -756,8 +759,6 @@ Some implementations of BigchainDB-compliant servers or drivers deviate from the
 ### BigchainDB Server Deviations
 
 <a href="https://github.com/bigchaindb/bigchaindb">BigchainDB Server</a> is a BigchainDB-compliant server implemented in Python.
-
-It allows <a href="#transaction-components-operation"><span>operation</span></a> to have the value `"GENESIS"`, but only for transactions in the GENESIS block.
 
 When BigchainDB Server is used *with MongoDB*, it inherits some quirks from MongoDB:
 


### PR DESCRIPTION
If the "version" of a transaction is "2.0" then "operation" can't be "GENESIS", it can only be "CREATE" or "TRANSFER". This change was made by @shahbazn in commit https://github.com/bigchaindb/bigchaindb/commit/e8e02cac5075b494eb6931f8c90bc43cf8cc0192 . This PR updates the BigchainDB Transactions Spec v2 (BEP-13) accordingly.

This PR also adds a subsection to the section on transaction validation to note that there are sometimes other rules that are specific to the implementation, with a link to that section. That change was made in both versions of the BigchainDB Transactions Spec, i.e. v1 and v2.
