### PR TITLE
Problem: BEP-17 spec is incomplete

### DIFF
--- a/17/README.md
+++ b/17/README.md
@@ -30,14 +30,26 @@ There is information about listing on Azure Marketplace in the Microsoft Azure h
 
 - Publish BigchainDB on Azure Marketplace or AppSource? Azure Marketplace.
 - What listing type? List, Trial or Transaction? Transaction.
+- Virtual machine or something else? Virtual machine.
 
-The next step is to become a "cloud partner publisher." We (BigchainDB GmbH) already signed up for something like that some time ago. We have an "azure publisher" account that can login to the Microsoft developer resources dashboard and the Microsoft Azure Publishing workspace as of May 9, 2018.
+We already have an "azure publisher" account which has enrolled in, signed up for, and otherwise gotten login rights for:
+
+* account.microsoft.com
+* Microsoft Dev Center at developer.microsoft.com/en-us/dashboard/overview
+* Azure Portal at portal.azure.com
+* Microsoft Partner Network at partner.microsoft.com
+* Cloud Partner Portal at cloudpartner.azure.com
+* Microsoft Azure Publishing workspace at publish.windowsazure.com/workspace/
 
 That account should be able to add more user accounts by going to cloudpartner.azure.com. The added user accounts will then have access the same Microsoft Azure Publishing workspace. The added user accounts can be Microsoft accounts or Azure accounts.
 
-We might have to do some more steps in the "2. Become a cloud partner publisher" section of that help page.
+We should publish a final/stable release of BigchainDB, i.e. BigchainDB 2.0.
 
-Lastly, we must do step "3. Complete offer and listing type prerequisites". For details, see the [Publisher Guide](https://docs.microsoft.com/en-us/azure/marketplace/marketplace-publishers-guide). The main _technical_ task is to create an Azure-compatible virtual hard disk (VHD). See the help page titled, "[How to use Packer to create Linux virtual machine images in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/build-image-with-packer)".
+The main _technical_ task is to create an Azure-compatible virtual hard disk (VHD).
+See the help page titled, "[How to use Packer to create Linux virtual machine images in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/build-image-with-packer)".
+The virtual machine image (VHD) can be stored under _any_ Azure subscription. It doesn't have to be stored under a subscription owned or managed by "azure publisher".
+
+One can create a "new offer" (virtual machine offer) at cloudpartner.azure.com.
 
 # Rationale
 


### PR DESCRIPTION
Solution: Add new information to BEP-17 to make it more complete

The content of the "Azure Marketplace and AppSource Publisher Guide" (page) changed since I wrote BEP-17. It's more of an overview now. Some of the numbered steps that I referenced are gone.

I fixed that, and added some new information:

- Where our "azure publisher" account can login. i.e. what it can do.
- We should publish a final/stable version of BigchainDB.
- Noted where one goes to create a "new offer" in Azure Marketplace.