### PR TITLE
Problem: The tx specs say that crypto-conditions are part of the ILP

### DIFF
--- a/12/README.md
+++ b/12/README.md
@@ -277,7 +277,7 @@ A subcondition can be implemented as an <a href="#associative-array"><span>assoc
 1. ED25519-SHA-256
 1. THRESHOLD-SHA-256
 
-Those names are from the <a href="https://tools.ietf.org/html/draft-thomas-crypto-conditions-03">crypto-conditions specification (spec)</a>, which is part of the Interledger Protocol (ILP). (It calls them "crypto-condition types.") The crypto-conditions spec includes other types, but the above types are the only ones used (currently).
+Those names are from the <a href="https://tools.ietf.org/html/draft-thomas-crypto-conditions-03">crypto-conditions specification (spec)</a>. (It calls them "crypto-condition types.") The crypto-conditions spec includes other types, but the above types are the only ones used (currently).
 
 Note: This version of the BigchainDB Transaction Spec conforms to versions 02 and 03 of the crypto-conditions spec. (The parts that it uses didn’t change from version 02 to 03.)
 

--- a/13/README.md
+++ b/13/README.md
@@ -307,7 +307,7 @@ A subcondition can be implemented as an <a href="#associative-array"><span>assoc
 1. ED25519-SHA-256
 1. THRESHOLD-SHA-256
 
-Those names are from the <a href="https://tools.ietf.org/html/draft-thomas-crypto-conditions-03">crypto-conditions specification (spec)</a>, which is part of the Interledger Protocol (ILP). (It calls them "crypto-condition types.") The crypto-conditions spec includes other types, but the above types are the only ones used (currently).
+Those names are from the <a href="https://tools.ietf.org/html/draft-thomas-crypto-conditions-03">crypto-conditions specification (spec)</a>. (It calls them "crypto-condition types.") The crypto-conditions spec includes other types, but the above types are the only ones used (currently).
 
 Note: This version of the BigchainDB Transaction Spec conforms to versions 02 and 03 of the crypto-conditions spec. (The parts that it uses didn’t change from version 02 to 03.)
 


### PR DESCRIPTION
Solution: Edit the tx specs so there's no mention of crypto-conditions being part of the ILP

For background on why Crypto Conditions were removed from the Interledger Protocol (ILP), see section 6 in the Interleger blog post at https://medium.com/interledger-blog/simplifying-interledger-the-graveyard-of-possible-protocol-features-b35bf67439be

Related PR: https://github.com/bigchaindb/bigchaindb/pull/2399 