### PR TITLE
Problem: Tx specs allowed TRANSFER asset.id == null

### DIFF
--- a/12/README.md
+++ b/12/README.md
@@ -450,7 +450,7 @@ In a CREATE transaction, an asset can be <a href="#ctnull"><span>ctnull</span></
 
 The meaning of a “valid associative array” may depend on the implementation; see the section about <a href="#implementation-specific-deviations"><span>implementation-specific deviations</span></a>.
 
-In a TRANSFER transaction, an asset can be <a href="#ctnull"><span>ctnull</span></a> (e.g. `None` in Python), or an <a href="#associative-array"><span>associative array</span></a> containing exactly one key-value pair. The key must be `"id"` and the value must be a 64-character hex string: a <a href="#transaction-components-transaction-id"><span>transaction ID</span></a>. Here’s a JSON example:
+In a TRANSFER transaction, an asset must be an <a href="#associative-array"><span>associative array</span></a> containing exactly one key-value pair. The key must be `"id"` and the value must be a 64-character hex string: a <a href="#transaction-components-transaction-id"><span>transaction ID</span></a>. Here’s a JSON example:
 
 ```json
 {

--- a/13/README.md
+++ b/13/README.md
@@ -478,7 +478,7 @@ In a CREATE transaction, an asset can be <a href="#ctnull"><span>ctnull</span></
 
 The meaning of a “valid associative array” may depend on the implementation; see the section about <a href="#implementation-specific-deviations"><span>implementation-specific deviations</span></a>.
 
-In a TRANSFER transaction, an asset can be <a href="#ctnull"><span>ctnull</span></a> (e.g. `None` in Python), or an <a href="#associative-array"><span>associative array</span></a> containing exactly one key-value pair. The key must be `"id"` and the value must be a 64-character hex string: a <a href="#transaction-components-transaction-id"><span>transaction ID</span></a>. Here’s a JSON example:
+In a TRANSFER transaction, an asset must be an <a href="#associative-array"><span>associative array</span></a> containing exactly one key-value pair. The key must be `"id"` and the value must be a 64-character hex string: a <a href="#transaction-components-transaction-id"><span>transaction ID</span></a>. Here’s a JSON example:
 
 ```json
 {


### PR DESCRIPTION
Solution: Edit the tx specs to only allow TRANSFER asset.id == {'id': <64-char hex string>}