### PR TITLE
Made all copyright waivers more consistent with Creative Commons guidelines

### DIFF
--- a/10/README.md
+++ b/10/README.md
@@ -135,8 +135,16 @@ The system is 100% compatible with the existing one. That's the goal of the incr
 The idea of this BEP is to share ideas on how we can move forward. For now, there is no specific implementation to describe how to do this in Go. We will create a public repository to experiment on this instead. This will give us some hands-on experience to understand how the actual implementation can be.
 
 ## Copyright Waiver
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
 
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>
 
 [bdb:post-tx]: https://docs.bigchaindb.com/projects/server/en/v2.0.0a1/http-client-server-api.html#post--api-v1-transactions?mode=mode
 [pyabci]: https://github.com/davebryson/py-abci/

--- a/12/README.md
+++ b/12/README.md
@@ -760,4 +760,12 @@ Any value which, when converted to JSON, becomes `null`. "ctnull" is short for "
 
 # Copyright Waiver
 
-_To the extent possible under law, the person who associated CC0 with this work (Troy McConaghy, editor) has waived all copyright and related or neighboring rights to this work._
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>

--- a/13/README.md
+++ b/13/README.md
@@ -793,4 +793,12 @@ Any value which, when converted to JSON, becomes `null`. "ctnull" is short for "
 
 # Copyright Waiver
 
-_To the extent possible under law, the person who associated CC0 with this work (Troy McConaghy, editor) has waived all copyright and related or neighboring rights to this work._
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>

--- a/14/README.md
+++ b/14/README.md
@@ -181,7 +181,16 @@ As long as the driver handles both single and multiple endpoints on its initiali
 The implementation is TBD.
 
 ## Copyright Waiver
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
+
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>
 
 [tm:light-client]: https://blog.cosmos.network/light-clients-in-tendermint-consensus-1237cfbda104
 [bdb:javascript-driver]: https://github.com/bigchaindb/js-bigchaindb-driver/

--- a/16/README.md
+++ b/16/README.md
@@ -79,4 +79,12 @@ The next step is to wait for them to copy that comment into the comments of the 
 
 # Copyright Waiver
 
-_To the extent possible under law, the person who associated CC0 with this work (Troy McConaghy, editor) has waived all copyright and related or neighboring rights to this work._
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>

--- a/17/README.md
+++ b/17/README.md
@@ -61,4 +61,12 @@ This section will be started once we do some of the things outlined in the Speci
 
 # Copyright Waiver
 
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>

--- a/18/README.md
+++ b/18/README.md
@@ -130,7 +130,16 @@ By now, this BEP has been implemented in:
 - [Dynamically add/update/remove Validators at runtime (BEP-21)][BEP-21]
 
 # Copyright Waiver
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
+
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>
 
 [BEP-3]: ../3
 [BEP-13]: ../13

--- a/19/README.md
+++ b/19/README.md
@@ -113,6 +113,18 @@ This could be implemented in two ways. First, we could simply experiment to find
 
 In any case, the sentinel server should function as a buffer between the request author and the Tendermint layer. Incoming requests should be stored in memory and fed to Tendermint at a manageable rate. Any pauses needed to maintain throughput on the Tendermint end should be invisible to the user, as the memory buffer stays available at all times.
 
+## Copyright Waiver
+
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>
+
 [tm_benchmark_claim]: https://github.com/tendermint/tendermint/wiki/Benchmarks
 [Tendermint]: http://tendermint.readthedocs.io/projects/tools/en/master/install.html
 [BEP-10]: https://github.com/bigchaindb/BEPs/blob/master/10/README.md

--- a/2/README.md
+++ b/2/README.md
@@ -82,7 +82,19 @@ Each BEP SHOULD include the following sections:
 
 1. **Implementation**. The implementations must be completed before any BEP is given status "stable", but it need not be completed before the BEP is accepted. While there is merit to the approach of reaching consensus on the BEP and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.
 
-1. **Copyright Waiver**. Except for BEP-1 (C4) and BEP-2 (COSS), all BEPs MUST be released to the public domain. The following waiver SHOULD be used: _To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work._
+1. **Copyright Waiver**. Except for BEP-1 (C4) and BEP-2 (COSS), all BEPs MUST be released to the public domain. To do that, the following block of HTML SHOULD be used in the BEP's source Markdown file. ([HTML is valid Markdown](https://daringfireball.net/projects/markdown/syntax#html).)
+
+```html
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>
+```
 
 The first 4 sections above are based on the [Leslie Lamport's note about describing solutions](https://lamport.azurewebsites.net/pubs/state-the-problem.pdf).
 

--- a/20/README.md
+++ b/20/README.md
@@ -60,4 +60,13 @@ Gitcoin as a platform supports the lifecycle of the bounty with Github integrati
 ![img](https://github.com/gitcoinco/web/raw/master/docs/bounty_flow.png) 
 
 ## Copyright Waiver
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
+
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>

--- a/21/README.md
+++ b/21/README.md
@@ -113,8 +113,16 @@ BigchainDB 2.0
 
 
 ## Copyright Waiver
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
 
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>
 
 [spec_validator_election]: ./transaction_validator_election_v2.0.yaml
 [spec_validator_election_vote]: ./transaction_validator_election_vote_v2.0.yaml

--- a/3/README.md
+++ b/3/README.md
@@ -122,4 +122,13 @@ BigchainDB 2.0
 
 
 ## Copyright Waiver
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
+
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>

--- a/4/README.md
+++ b/4/README.md
@@ -162,4 +162,13 @@ unstable
 
 
 ## Copyright Waiver
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
+
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>

--- a/42/README.md
+++ b/42/README.md
@@ -82,4 +82,13 @@ Following describes how to archive and start a new blockchain,
 
 ## Copyright Waiver
 
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>
+

--- a/5/README.md
+++ b/5/README.md
@@ -144,4 +144,12 @@ BigchainDB GmbH has a process to improve BEPs like this one. Please see [BEP-1 (
 
 ## Copyright Waiver
 
-_To the extent possible under law, the person who associated CC0 with this work_ (Troy McConaghy, editor) _has waived all copyright and related or neighboring rights to this work._
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>

--- a/6/README.md
+++ b/6/README.md
@@ -30,4 +30,13 @@ SWP provides a reusable collaboration model for people working in the same works
 1. A person MUST NOT have calls unless everyone in the room is involved.
 
 ## Copyright Waiver
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
+
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>

--- a/7/README.md
+++ b/7/README.md
@@ -44,4 +44,12 @@ At the time of writing, the various components of the BigchainDB Public API were
 
 # Copyright Waiver
 
-_To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work._
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>

--- a/8/README.md
+++ b/8/README.md
@@ -76,4 +76,13 @@ Following from the previous section, the metadata for `COMMIT` is stored in `pre
 
 
 ## Copyright Waiver
-To the extent possible under law, the person who associated CC0 with this work has waived all copyright and related or neighboring rights to this work.
+
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law, all contributors to this BEP
+  have waived all copyright and related or neighboring rights to this BEP.
+</p>


### PR DESCRIPTION
Use some HTML markup suggested by Creative Commons, including the CC0 "Public Domain" image and a link to the Creative Commons web page with a human-readable summary of the legal code, i.e. http://creativecommons.org/publicdomain/zero/1.0/

